### PR TITLE
[feat] claim이 승인 상태일 경우, 해당 리소스가 삭제되기 전까지 claim이 삭제되는 것을 웹훅에서 막는 기능 추가

### DIFF
--- a/api/v1alpha1/namespaceclaim_webhook.go
+++ b/api/v1alpha1/namespaceclaim_webhook.go
@@ -56,7 +56,6 @@ func (r *NamespaceClaim) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NamespaceClaim) ValidateUpdate(old runtime.Object) error {
 	namespaceclaimlog.Info("validate update", "name", r.Name)
-	// TODO(user): fill in your validation logic upon object update.
 	old_status := old.(*NamespaceClaim).DeepCopy().Status.Status
 	now_status := r.Status.Status
 
@@ -65,7 +64,7 @@ func (r *NamespaceClaim) ValidateUpdate(old runtime.Object) error {
 		return errors.NewForbidden(
 			schema.GroupResource{Group: "claim.tmax.io", Resource: r.Name},
 			"",
-			err.New("cannot update NamespaceClaim in Approved or Deleted status"),
+			err.New("Cannot update NamespaceClaim in Approved or Deleted status"),
 		)
 	}
 
@@ -75,7 +74,9 @@ func (r *NamespaceClaim) ValidateUpdate(old runtime.Object) error {
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *NamespaceClaim) ValidateDelete() error {
 	namespaceclaimlog.Info("validate delete", "name", r.Name)
-	// TODO(user): fill in your validation logic upon object deletion.
+	if r.Status.Status == NamespaceClaimStatusTypeSuccess {
+		return err.New("Cannot delete NamespaceClaim before deleting Namespace")
+	}
 	return nil
 }
 

--- a/api/v1alpha1/resourcequotaclaim_webhook.go
+++ b/api/v1alpha1/resourcequotaclaim_webhook.go
@@ -95,7 +95,6 @@ func (r *ResourceQuotaClaim) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *ResourceQuotaClaim) ValidateUpdate(old runtime.Object) error {
 	resourcequotaclaimlog.Info("validate update", "name", r.Name)
-	// TODO(user): fill in your validation logic upon object update.
 	old_status := old.(*ResourceQuotaClaim).DeepCopy().Status.Status
 	now_status := r.Status.Status
 
@@ -104,7 +103,7 @@ func (r *ResourceQuotaClaim) ValidateUpdate(old runtime.Object) error {
 		return errors.NewForbidden(
 			schema.GroupResource{Group: "claim.tmax.io", Resource: r.Name},
 			"",
-			err.New("cannot update ResourceQuotaClaim in Approved or Deleted status"),
+			err.New("Cannot update ResourceQuotaClaim in Approved or Deleted status"),
 		)
 	}
 
@@ -114,7 +113,9 @@ func (r *ResourceQuotaClaim) ValidateUpdate(old runtime.Object) error {
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *ResourceQuotaClaim) ValidateDelete() error {
 	resourcequotaclaimlog.Info("validate delete", "name", r.Name)
-	// TODO(user): fill in your validation logic upon object deletion.
+	if r.Status.Status == ResourceQuotaClaimStatusTypeSuccess {
+		return err.New("Cannot delete ResourceQuotaClaim before deleting ResourceQuota")
+	}
 	return nil
 }
 

--- a/api/v1alpha1/rolebindingclaim_webhook.go
+++ b/api/v1alpha1/rolebindingclaim_webhook.go
@@ -48,14 +48,12 @@ var _ webhook.Validator = &RoleBindingClaim{}
 func (r *RoleBindingClaim) ValidateCreate() error {
 	rolebindingclaimlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *RoleBindingClaim) ValidateUpdate(old runtime.Object) error {
 	rolebindingclaimlog.Info("validate update", "name", r.Name)
-	// TODO(user): fill in your validation logic upon object update.
 
 	old_status := old.(*RoleBindingClaim).DeepCopy().Status.Status
 	now_status := r.Status.Status
@@ -65,7 +63,7 @@ func (r *RoleBindingClaim) ValidateUpdate(old runtime.Object) error {
 		return errors.NewForbidden(
 			schema.GroupResource{Group: "claim.tmax.io", Resource: r.Name},
 			"",
-			err.New("cannot update RoleBindingClaim in Approved or Deleted status"),
+			err.New("Cannot update RoleBindingClaim in Approved or Deleted status"),
 		)
 	}
 
@@ -75,7 +73,8 @@ func (r *RoleBindingClaim) ValidateUpdate(old runtime.Object) error {
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *RoleBindingClaim) ValidateDelete() error {
 	rolebindingclaimlog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
+	if r.Status.Status == RoleBindingClaimStatusTypeSuccess {
+		return err.New("Cannot delete RoleBindingClaim before deleting Rolebinding")
+	}
 	return nil
 }

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,6 +24,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - namespaceclaims
     - namespaceclaims/status
@@ -46,31 +47,10 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - resourcequotaclaims
     - resourcequotaclaims/status
-  sideEffects: NoneOnDryRun
-- admissionReviewVersions:
-  - v1beta1
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-claim-tmax-io-v1alpha1-namespaceclaim
-  failurePolicy: Fail
-  name: vnamespaceclaim.kb.io
-  rules:
-  - apiGroups:
-    - claim.tmax.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - namespaceclaims
-    - namespaceclaims/status
   sideEffects: NoneOnDryRun
 - admissionReviewVersions:
   - v1beta1
@@ -90,28 +70,8 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
+    - rolebindingclaims
     - rolebindingclaims/status
-  sideEffects: NoneOnDryRun
-- admissionReviewVersions:
-  - v1beta1
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-claim-tmax-io-v1alpha1-namespaceclaim
-  failurePolicy: Fail
-  name: vnamespaceclaim.kb.io
-  rules:
-  - apiGroups:
-    - claim.tmax.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - namespaceclaims
-    - namespaceclaims/status
   sideEffects: NoneOnDryRun


### PR DESCRIPTION
승인 상태외에 나머지 4개의 상태의 경우 지울 수 있도록 허용함
(대기, 거절, 에러, 삭제)